### PR TITLE
:factory: Use GITHUB_TOKEN instead of my own PAT

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
https://github.com/docker/login-action/tree/d398f07826957cd0a18ea1b059cf1207835e60bc#github-container-registry